### PR TITLE
Fix for issue of parsing long message.

### DIFF
--- a/src/MessageHelper.cs
+++ b/src/MessageHelper.cs
@@ -37,7 +37,7 @@ namespace HL7.Dotnetcore
         public static string[] ExtractMessages(string messages)
         {
             var expr = "\x0B(.*?)\x1C\x0D";
-            var matches = Regex.Matches(messages, expr);
+            var matches = Regex.Matches(messages, expr, RegexOptions.Singleline);
             
             var list = new List<string>();
             foreach (Match m in matches)


### PR DESCRIPTION

Fixes Issue #19.

Explicitly specify to tread incoming string as a single line.  This allows to break messages properly.