### PR TITLE
Update nuget reference versions to fix compilation warnings

### DIFF
--- a/HL7-dotnetcore.sln
+++ b/HL7-dotnetcore.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "hl7-dotnetcore", "src\hl7-dotnetcore.csproj", "{8D0228F0-7BE1-4D45-9EB4-8E170F76A17E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "hl7-dotnetcore", "src\HL7-dotnetcore.csproj", "{8D0228F0-7BE1-4D45-9EB4-8E170F76A17E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "hl7test", "test\hl7test.csproj", "{910F6F49-6AD7-45EF-8FA0-E141C77D81DA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "hl7test", "test\HL7test.csproj", "{910F6F49-6AD7-45EF-8FA0-E141C77D81DA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/HL7-dotnetcore.csproj
+++ b/src/HL7-dotnetcore.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime" Version="*" />
-    <PackageReference Include="System.Runtime.Extensions" Version="*" />
-    <PackageReference Include="System.Linq" Version="*" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="*" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/test/HL7test.csproj
+++ b/test/HL7test.csproj
@@ -26,6 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\hl7-dotnetcore.csproj" />
+    <ProjectReference Include="..\src\HL7-dotnetcore.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Added specific version to nuget references in .csproj to fix compilation warnings
- Fixed casing of project file references to allow compilation on linux

Tested by compiling and running tests on:
- Visual Studio 2017 in Windows 10
- dotnet 2.1 cli on Ubuntu 18.04

Fixes #30 
