### PR TITLE
Fix for 32

### DIFF
--- a/src/Encoding.cs
+++ b/src/Encoding.cs
@@ -13,6 +13,7 @@ namespace HL7.Dotnetcore
         public char EscapeCharacter { get; set; } = '\\'; // \E\
         public char SubComponentDelimiter { get; set; } = '&'; // \T\
         public string SegmentDelimiter { get; set; } = "\r";
+         public string PresentButNull {get;set;}= "\"\"";
 
         public HL7Encoding()
         {
@@ -47,6 +48,9 @@ namespace HL7.Dotnetcore
 
         public  string Encode(string val)
         {
+            if(val == null) {
+                return PresentButNull;
+            }
             if (string.IsNullOrWhiteSpace(val))
                 return val;
 

--- a/src/Encoding.cs
+++ b/src/Encoding.cs
@@ -13,7 +13,7 @@ namespace HL7.Dotnetcore
         public char EscapeCharacter { get; set; } = '\\'; // \E\
         public char SubComponentDelimiter { get; set; } = '&'; // \T\
         public string SegmentDelimiter { get; set; } = "\r";
-         public string PresentButNull {get;set;}= "\"\"";
+        public string PresentButNull {get;set;}= "\"\"";
 
         public HL7Encoding()
         {

--- a/src/MessageElement.cs
+++ b/src/MessageElement.cs
@@ -3,13 +3,13 @@ namespace HL7.Dotnetcore
     public abstract class MessageElement
     {
         protected string _value = string.Empty;
-        const string presentButNull = "\"\"";
+       
         
         public  string Value 
         { 
             get 
             {
-                return _value == presentButNull ? null : _value; 
+                return _value == Encoding.PresentButNull ? null : _value; 
             }
             set 
             { 

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -269,16 +269,27 @@ namespace HL7.Dotnetcore.Test
         [TestMethod]
         public void EmptyAndNullFieldsTest()
         {
-            const string sampleMessage = "MSH|^~\\&|SA|SF|RA|RF|20110613083617||ADT^A04|123|P|2.7||||\r\nEVN|A04|20110613083617||\"\"";
+            const string sampleMessage = "MSH|^~\\&|SA|SF|RA|RF|20110613083617||ADT^A04|123|P|2.7||||\r\nEVN|A04|20110613083617||\"\"\r\n";
 
             var message = new Message(sampleMessage);
-            message.ParseMessage();
+            var isParsed = message.ParseMessage();
+            Assert.IsTrue(isParsed);
+            Assert.IsTrue(message.SegmentCount > 0);
             var evn = message.Segments("EVN")[0];
-
             var expectEmpty = evn.Fields(3).Value;
             Assert.AreEqual(string.Empty, expectEmpty);
             var expectNull = evn.Fields(4).Value;
             Assert.AreEqual(null, expectNull);
+        }
+
+
+        [TestMethod]
+        public void ParseIsReversable() {
+            const string sampleMessage = "MSH|^~\\&|SA|SF|RA|RF|20110613083617||ADT^A04|123|P|2.7||||\r\nEVN|A04|20110613083617||\"\"\r\n";
+            var message = new Message(sampleMessage);
+            message.ParseMessage();
+            var serialized = message.SerializeMessage(false);
+            Assert.AreEqual(sampleMessage, serialized);
         }
     }
 }

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -284,7 +284,7 @@ namespace HL7.Dotnetcore.Test
 
 
         [TestMethod]
-        public void ParseIsReversable() {
+        public void QuoteChangeIsReversable() {
             const string sampleMessage = "MSH|^~\\&|SA|SF|RA|RF|20110613083617||ADT^A04|123|P|2.7||||\r\nEVN|A04|20110613083617||\"\"\r\n";
             var message = new Message(sampleMessage);
             message.ParseMessage();

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -284,7 +284,7 @@ namespace HL7.Dotnetcore.Test
 
 
         [TestMethod]
-        public void QuoteChangeIsReversable() {
+        public void MessageWithNullsIsReversable() {
             const string sampleMessage = "MSH|^~\\&|SA|SF|RA|RF|20110613083617||ADT^A04|123|P|2.7||||\r\nEVN|A04|20110613083617||\"\"\r\n";
             var message = new Message(sampleMessage);
             message.ParseMessage();


### PR DESCRIPTION
The cause of the error is that the HL7 null ("") is converted to null by your code when parsing retrieving the value, but is not reverted to "" when serializing.

I can't see any other circumstance where value will be null so this resolves the issue.