### PR TITLE
added remove trailing component feature with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,42 @@ After evaluated and modified required values, the message can be obtained again 
 string strUpdatedMsg = message.SerializeMessage();
 ````
 
+### Remove Trailing Components
+
+```csharp
+var message = new Message();
+
+// create ORC segment
+var orcSegment = new Segment("ORC", new HL7Encoding());
+
+// add fields
+for (int eachField = 1; eachField <= 12; eachField++)
+{
+    orcSegment.AddEmptyField();
+}
+
+// add components to field 12
+for (int eachField = 1; eachField < 8; eachField++)
+{
+    orcSegment.Fields(12).AddNewComponent(new Component(new HL7Encoding()));
+}
+
+// add values to components
+orcSegment.Fields(12).Components(1).Value = "should not be removed";
+orcSegment.Fields(12).Components(2).Value = "should not be removed";
+orcSegment.Fields(12).Components(3).Value = "should not be removed";
+orcSegment.Fields(12).Components(4).Value = ""; // should not be removed because in between valid values
+orcSegment.Fields(12).Components(5).Value = "should not be removed";
+orcSegment.Fields(12).Components(6).Value = ""; // should be removed because trailing
+orcSegment.Fields(12).Components(7).Value = ""; // should be removed because trailing
+orcSegment.Fields(12).Components(8).Value = ""; // should be removed because trailing
+
+orcSegment.Fields(12).RemoveEmptyTrailingComponents();
+message.AddNewSegment(orcSegment);
+
+string serializedMessage = message.SerializeMessage(false);
+```
+
 ### Remove a Segment
 
 Segments are removed individually, including the case where there are repeated segments with the same name

--- a/src/Field.cs
+++ b/src/Field.cs
@@ -149,5 +149,25 @@ namespace HL7.Dotnetcore
             }
             return null;
         }
+
+        public bool RemoveEmptyTrailingComponents()
+        {
+            try
+            {
+                for (var eachComponent = ComponentList.Count - 1; eachComponent >= 0; eachComponent--)
+                {
+                    if (ComponentList[eachComponent].Value == "")
+                        ComponentList.Remove(ComponentList[eachComponent]);
+                    else
+                        break;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                throw new HL7Exception("Error removing trailing comonents - " + ex.Message);
+            }
+        }
     }
 }

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -411,5 +411,63 @@ PV1||O|NWSLED^^^NYULHLI^^^^^LI NW SLEEP DISORDER^^DEPID||||1447312459^DOE^MICHAE
             string attendingDrId = message.GetValue(index);
             Assert.AreEqual(expected, attendingDrId);
         }
+
+        [TestMethod]
+        public void RemoveTrailingComponentsTest_OnlyTrailingComponentsRemoved()
+        {
+            var message = new Message();
+
+            var orcSegment = new Segment("ORC", new HL7Encoding());
+            for (int eachField = 1; eachField <= 12; eachField++)
+            {
+                orcSegment.AddEmptyField();
+            }
+
+            for (int eachComponent = 1; eachComponent < 8; eachComponent++)
+            {
+                orcSegment.Fields(12).AddNewComponent(new Component(new HL7Encoding()));
+            }
+
+            orcSegment.Fields(12).Components(1).Value = "should not be removed";
+            orcSegment.Fields(12).Components(2).Value = "should not be removed";
+            orcSegment.Fields(12).Components(3).Value = "should not be removed";
+            orcSegment.Fields(12).Components(4).Value = ""; // should not be removed because in between valid values
+            orcSegment.Fields(12).Components(5).Value = "should not be removed";
+            orcSegment.Fields(12).Components(6).Value = ""; // should be removed because trailing
+            orcSegment.Fields(12).Components(7).Value = ""; // should be removed because trailing
+            orcSegment.Fields(12).Components(8).Value = ""; // should be removed because trailing
+
+            orcSegment.Fields(12).RemoveEmptyTrailingComponents();
+            message.AddNewSegment(orcSegment);
+
+            string serializedMessage = message.SerializeMessage(false);
+            Assert.AreEqual(orcSegment.Fields(12).Components().Count, 5);
+            Assert.AreEqual("ORC||||||||||||should not be removed^should not be removed^should not be removed^^should not be removed\r", serializedMessage);
+        }
+
+        [TestMethod]
+        public void RemoveTrailingComponentsTest_RemoveAllFieldComponentsIfEmpty()
+        {
+            var message = new Message();
+
+            var orcSegment = new Segment("ORC", new HL7Encoding());
+            for (int eachField = 1; eachField <= 12; eachField++)
+            {
+                orcSegment.AddEmptyField();
+            }
+
+            for (int eachComponent = 1; eachComponent < 8; eachComponent++)
+            {
+                orcSegment.Fields(12).AddNewComponent(new Component(new HL7Encoding()));
+                orcSegment.Fields(12).Components(eachComponent).Value = "";
+            }
+
+            orcSegment.Fields(12).RemoveEmptyTrailingComponents();
+            message.AddNewSegment(orcSegment);
+
+            string serializedMessage = message.SerializeMessage(false);
+            Assert.AreEqual(orcSegment.Fields(12).Components().Count, 0);
+            Assert.AreEqual("ORC||||||||||||\r", serializedMessage);
+        }
     }
 }


### PR DESCRIPTION
When putting together components in a field, it would be nice to remove components that don't get used after the field components have been added. 

For example, 
`ORC||||||||||||should not be removed^should not be removed^should not be removed^^should not be removed^^^\r`

Would have the trailing components in field 12 removed to look like this:
`ORC||||||||||||should not be removed^should not be removed^should not be removed^^should not be removed\r`

To do this, I created a simple method on the `Field` class called `RemoveEmptyTrailingComponents` that will, starting at the end, loop through all the components in a field and remove each empty component until it finds a value. If all components in the field contain a value they will all be removed.

I've added a couple of tests to confirm and demo the functionality. I've also added a section to the README to demo the capability to devs. 