### PR TITLE
Ability to bypass validation when parsing a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ foreach (var strMsg in messages)
     // do something with the message object
 }
 ````
-
+## Bypass Validation
+````cSharp
+Message  message = new Message(strMsg)
+message.ParseMessage(true);
+````
 ## Accessing Segments
 
 ### Get list of all segments

--- a/src/HL7-dotnetcore.csproj
+++ b/src/HL7-dotnetcore.csproj
@@ -2,21 +2,21 @@
   <PropertyGroup>
     <Description>Lightweight HL7 2.x library compatible with .Net Standard and .Net Core</Description>
     <Copyright>(c) Efferent Health, LLC</Copyright>
-    <VersionPrefix>2.24.0</VersionPrefix>
+    <VersionPrefix>2.24.1</VersionPrefix>
     <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
-    <AssemblyName>HL7-dotnetcore</AssemblyName>
-    <PackageId>HL7-dotnetcore</PackageId>
+    <AssemblyName>HL7-dotnetcore-Fork-Garcia</AssemblyName>
+    <PackageId>HL7-dotnetcore-Fork-Garcia</PackageId>
     <PackageTags>hl7;dotnetcore</PackageTags>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/Efferent-Health/HL7-dotnetcore</RepositoryUrl>
+    <RepositoryUrl>https://github.com/GG-Garcia/HL7-dotnetcore</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageTags>hl7 dotnetcore hl7-parser hl7-writer</PackageTags>
-    <PackageProjectUrl>https://github.com/Efferent-Health/HL7-dotnetcore</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/GG-Garcia/HL7-dotnetcore</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/Efferent-Health/HL7-dotnetcore</RepositoryUrl>
+    <RepositoryUrl>https://github.com/GG-Garcia/HL7-dotnetcore</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/HL7-dotnetcore.csproj
+++ b/src/HL7-dotnetcore.csproj
@@ -2,21 +2,21 @@
   <PropertyGroup>
     <Description>Lightweight HL7 2.x library compatible with .Net Standard and .Net Core</Description>
     <Copyright>(c) Efferent Health, LLC</Copyright>
-    <VersionPrefix>2.24.1</VersionPrefix>
+    <VersionPrefix>2.24.0</VersionPrefix>
     <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
-    <AssemblyName>HL7-dotnetcore-Fork-Garcia</AssemblyName>
-    <PackageId>HL7-dotnetcore-Fork-Garcia</PackageId>
+    <AssemblyName>HL7-dotnetcore</AssemblyName>
+    <PackageId>HL7-dotnetcore</PackageId>
     <PackageTags>hl7;dotnetcore</PackageTags>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/GG-Garcia/HL7-dotnetcore</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Efferent-Health/HL7-dotnetcore</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageTags>hl7 dotnetcore hl7-parser hl7-writer</PackageTags>
-    <PackageProjectUrl>https://github.com/GG-Garcia/HL7-dotnetcore</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/Efferent-Health/HL7-dotnetcore</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/GG-Garcia/HL7-dotnetcore</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Efferent-Health/HL7-dotnetcore</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -56,15 +56,20 @@ namespace HL7.Dotnetcore
         /// <summary>
         /// Parse the HL7 message in text format, throws HL7Exception if error occurs
         /// </summary>
+        /// <param name="bypassValidation">To parse the message without any validation</param>
         /// <returns>boolean</returns>
-        public bool ParseMessage()
+        public bool ParseMessage(bool bypassValidation = false)
         {
             bool isValid = false;
             bool isParsed = false;
 
             try
             {
-                isValid = this.validateMessage();
+                if (!bypassValidation)
+                {
+                    isValid = this.validateMessage();
+                }
+                else { isValid = true; }
             }
             catch (HL7Exception ex)
             {


### PR DESCRIPTION
Problem: When trying to parse an HL7 message, although some data is missing, it should still allow me to parse the files without any issue. The current program hits an exception and forces you to fix it.  I should be able to grab the data without relying on the validation.

Solution: I created an optional bypassValidation boolean to skip the validation procedure. It now works as needed.