### PR TITLE
SetValue for all repeating Segments

### DIFF
--- a/src/Message.cs
+++ b/src/Message.cs
@@ -302,7 +302,7 @@ namespace HL7.Dotnetcore
         }
 
         /// <summary>
-        /// Sets the Value of specific Field/Component/SubCpomponent, throws error if field/component index is not valid
+        /// Sets the Value of specific Field/Component/SubComponent in matching Segments, throws error if field/component index is not valid
         /// </summary>
         /// <param name="strValueFormat">Field/Component position in format SEGMENTNAME.FieldIndex.ComponentIndex.SubComponentIndex example PID.5.2</param>
         /// <param name="strValue">Value for the specified field/component</param>
@@ -323,56 +323,58 @@ namespace HL7.Dotnetcore
 
                 if (SegmentList.ContainsKey(segmentName))
                 {
-                    var segment = SegmentList[segmentName].First();
+                    foreach (var segment in SegmentList[segmentName])
+                    {
+                        if (comCount == 4)
+                        {
+                            Int32.TryParse(allComponents[2], out componentIndex);
+                            Int32.TryParse(allComponents[3], out subComponentIndex);
 
-                    if (comCount == 4)
-                    {
-                        Int32.TryParse(allComponents[2], out componentIndex);
-                        Int32.TryParse(allComponents[3], out subComponentIndex);
+                            try
+                            {
+                                var field = this.getField(segment, allComponents[1]);
+                                field.ComponentList[componentIndex - 1].SubComponentList[subComponentIndex - 1].Value = strValue;
+                                isSet = true;
+                            }
+                            catch (Exception ex)
+                            {
+                                throw new HL7Exception("SubComponent not available - " + strValueFormat + " Error: " + ex.Message);
+                            }
+                        }
+                        else if (comCount == 3)
+                        {
+                            Int32.TryParse(allComponents[2], out componentIndex);
 
-                        try
-                        {
-                            var field = this.getField(segment, allComponents[1]);
-                            field.ComponentList[componentIndex - 1].SubComponentList[subComponentIndex - 1].Value = strValue;
-                            isSet = true;
+                            try
+                            {
+                                var field = this.getField(segment, allComponents[1]);
+                                field.ComponentList[componentIndex - 1].Value = strValue;
+                                isSet = true;
+                            }
+                            catch (Exception ex)
+                            {
+                                throw new HL7Exception("Component not available - " + strValueFormat + " Error: " + ex.Message);
+                            }
                         }
-                        catch (Exception ex)
+                        else if (comCount == 2)
                         {
-                            throw new HL7Exception("SubComponent not available - " + strValueFormat + " Error: " + ex.Message);
+                            try
+                            {
+                                var field = this.getField(segment, allComponents[1]);
+                                field.Value = strValue;
+                                isSet = true;
+                            }
+                            catch (Exception ex)
+                            {
+                                throw new HL7Exception("Field not available - " + strValueFormat + " Error: " + ex.Message);
+                            }
+                        }
+                        else
+                        {
+                            throw new HL7Exception("Cannot overwrite a segment value");
                         }
                     }
-                    else if (comCount == 3)
-                    {
-                        Int32.TryParse(allComponents[2], out componentIndex);
 
-                        try
-                        {
-                            var field = this.getField(segment, allComponents[1]);
-                            field.ComponentList[componentIndex - 1].Value = strValue;
-                            isSet = true;
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new HL7Exception("Component not available - " + strValueFormat + " Error: " + ex.Message);
-                        }
-                    }
-                    else if (comCount == 2)
-                    {
-                        try
-                        {
-                            var field = this.getField(segment, allComponents[1]);
-                            field.Value = strValue;
-                            isSet = true;
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new HL7Exception("Field not available - " + strValueFormat + " Error: " + ex.Message);
-                        }
-                    }
-                    else
-                    {
-                        throw new HL7Exception("Cannot overwrite a segment value");
-                    }
                 }
                 else
                     throw new HL7Exception("Segment name not available");

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -645,5 +645,47 @@ PV1||A|00004620^00001318^1318||||000123456^Superfrau^Maria W.^|^Superarzt^Anton^
             Assert.AreEqual("MARIE", firstNK1UnchangedValue);
             Assert.AreEqual("JHON", secondNk1UnchangedValue);
         }
+
+        [TestMethod]
+        public void SetValueUnavailableComponents()
+        {
+            var sampleMessage = @"MSH|^~\&|SYSTEM1|ABC|SYSTEM2||201803262027||DFT^P03|20180326202737608457|P|2.3|||"
+                                    +"\nPID|1|0002381795|0002381795||Supermann^Peter^^^Herr||19990101|M|||";
+            var testValue = "test";
+            var message = new Message(sampleMessage);
+            message.ParseMessage();
+
+            var invalidRequest = Assert.ThrowsException<HL7Exception>(() => message.SetValue("", testValue));
+            Assert.IsTrue(invalidRequest.Message.Contains("Request format"), "Should have thrown exception because of invalid request format");
+            
+            var unavailableSegment = Assert.ThrowsException<HL7Exception>(() => message.SetValue("OBX.1", testValue));
+            Assert.IsTrue(unavailableSegment.Message.Contains("Segment name"), "Should have thrown exception because of unavailable Segment");
+            
+            var segmentLevel = Assert.ThrowsException<HL7Exception>(() => message.SetValue("PID.30", testValue));
+            Assert.IsTrue(segmentLevel.Message.Contains("Field not available"), "Should have thrown exception because of unavailable Field");
+            
+            var componentLevel = Assert.ThrowsException<HL7Exception>(() => message.SetValue("PID.3.7", testValue));
+            Assert.IsTrue(componentLevel.Message.Contains("Component not available"), "Should have thrown exception because of unavailable Component");
+            
+            var subComponentLevel = Assert.ThrowsException<HL7Exception>(() => message.SetValue("PID.3.1.2", testValue));
+            Assert.IsTrue(subComponentLevel.Message.Contains("SubComponent not available"), "Should have thrown exception because of unavailable SubComponent");
+        }
+
+        [TestMethod]
+        public void SetValueAvailableComponents()
+        {
+            var testValue = "test";
+            var message = new Message(HL7_ADT);
+            message.ParseMessage();
+
+            Assert.IsTrue(message.SetValue("PID.1", testValue), "Should have successfully set value of Field");
+            Assert.AreEqual(testValue, message.GetValue("PID.1"));
+            
+            Assert.IsTrue(message.SetValue("PID.2.2", testValue), "Should have successfully set value of Component");
+            Assert.AreEqual(testValue, message.GetValue("PID.2.2"));
+            
+            Assert.IsTrue(message.SetValue("PID.2.4.1", testValue), "Should have successfully set value of SubComponent");
+            Assert.AreEqual(testValue, message.GetValue("PID.2.4.1"));
+        }
     }
 }

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -608,5 +608,42 @@ PV1||A|00004620^00001318^1318||||000123456^Superfrau^Maria W.^|^Superarzt^Anton^
             Assert.AreEqual("PID|A~B\r", str);
         }
 
+        [TestMethod]
+        public void SetValueSingleSegment()
+        {
+            var strValueFormat = "PID.2.1";
+            var unchangedValuePath = "PID.3.1";
+            var newPatientId = "1234567";
+            var message = new Message(HL7_ADT);
+            message.ParseMessage();
+
+            message.SetValue(strValueFormat, newPatientId);
+            
+            Assert.AreEqual(newPatientId, message.GetValue(strValueFormat));
+            Assert.AreEqual("454721", message.GetValue(unchangedValuePath));
+        }
+
+        [TestMethod]
+        public void SetValueRepeatingSegments()
+        {
+            var strValueFormat = "NK1.2.1";
+            var unchangedValuePath = "NK1.2.2";
+            var newFamilyName = "SCHMOE";
+            var message = new Message(HL7_ADT);
+            message.ParseMessage();
+
+            message.SetValue(strValueFormat, newFamilyName);
+
+            var firstNK1ChangedValue = message.GetValue(strValueFormat);
+            var firstNK1UnchangedValue = message.GetValue(unchangedValuePath);
+            Assert.IsTrue(message.RemoveSegment("NK1", 0));
+            var secondNk1ChangedValue = message.GetValue(strValueFormat);
+            var secondNk1UnchangedValue = message.GetValue(unchangedValuePath);
+
+            Assert.AreEqual(newFamilyName, firstNK1ChangedValue);
+            Assert.AreEqual(newFamilyName, secondNk1ChangedValue);
+            Assert.AreEqual("MARIE", firstNK1UnchangedValue);
+            Assert.AreEqual("JHON", secondNk1UnchangedValue);
+        }
     }
 }


### PR DESCRIPTION
When trying to set a new value for a specific Field/Component/SubComponent identified through a given path, you could only alter the first segment with the given name. Therefore you were not able to alter repeating Segments like NK1 (by path).

This PR extends SetValue so that it now also works on all repeating segments.