### PR TITLE
Fix double decoding of Value On Message GetValue Closes #120

### DIFF
--- a/src/Message.cs
+++ b/src/Message.cs
@@ -309,7 +309,7 @@ namespace HL7.Dotnetcore
                 throw new HL7Exception("Request format is not valid: " + strValueFormat);
             }
 
-            return this.Encoding.Decode(strValue);
+            return strValue;
         }
 
         /// <summary>


### PR DESCRIPTION
It appears as though decoding already happens in the individual message elements. So decoding at the end of the GetValue function appeared to be double decoding, which could corrupt the text value expected.