### PR TITLE
perf: Initial set of performance improvements that aren't net8 specific

### DIFF
--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Update="Sample-ORM.txt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+        <PackageReference Include="HL7-dotnetcore" Version="2.37.1" Condition="!$(DefineConstants.Contains('LOCAL_CODE'))" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- only include a direct code ref for net8, use nuget otherwise -->
+        <ProjectReference Include="..\src\HL7-dotnetcore.csproj" Condition="$(DefineConstants.Contains('LOCAL_CODE'))" />
+    </ItemGroup>
+
+
+</Project>

--- a/Benchmarks/ParseMessageBench.cs
+++ b/Benchmarks/ParseMessageBench.cs
@@ -1,0 +1,63 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using HL7.Dotnetcore;
+using System.IO;
+
+namespace Benchmarks
+{
+    /// <summary>
+    /// Basic benchmark comparing the nuget version to our local code, for both Framework 4.8 and net8.  Calls a copy of one of the tests
+    /// that best reflects my usage scenarios (Parse and GetValue)
+    /// </summary>
+    [Config(typeof(Config))]
+    [MemoryDiagnoser]
+    [HideColumns("BuildConfiguration", "NuGetReferences", "Runtime")]
+    public class ParseMessageBench
+    {
+        private readonly string _sampleMessage = File.ReadAllText("Sample-Orm.txt");
+
+/*
+| Method                   | Job          | Mean     | Error     | StdDev   | Ratio | RatioSD | Gen0    | Gen1   | Allocated | Alloc Ratio |
+|------------------------- |------------- |---------:|----------:|---------:|------:|--------:|--------:|-------:|----------:|------------:|
+| ParseMessageAndGetValues | Local Net4.8 | 96.03 us |  5.445 us | 0.298 us |  1.83 |    0.01 | 40.5273 | 5.9814 | 249.26 KB |        1.18 |
+| ParseMessageAndGetValues | Local Net8   | 50.55 us | 21.651 us | 1.187 us |  0.96 |    0.02 | 12.2070 | 2.0142 | 187.36 KB |        0.89 |
+| ParseMessageAndGetValues | Nuget Net4.8 | 97.66 us | 38.600 us | 2.116 us |  1.86 |    0.05 | 44.4336 | 6.8359 | 273.48 KB |        1.30 |
+| ParseMessageAndGetValues | Nuget Net8   | 52.39 us |  6.528 us | 0.358 us |  1.00 |    0.00 | 13.7329 | 2.3193 | 211.17 KB |        1.00 |
+
+
+ */
+
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                var baseJob = Job.ShortRun;
+
+                AddJob(baseJob.WithNuGet("HL7-dotnetcore", "2.37.1").WithRuntime(CoreRuntime.Core80).WithId("Nuget Net8").AsBaseline());
+                AddJob(baseJob.WithNuGet("HL7-dotnetcore", "2.37.1").WithRuntime(ClrRuntime.Net48).WithId("Nuget Net4.8"));
+
+                AddJob(baseJob.WithRuntime(ClrRuntime.Net48).WithCustomBuildConfiguration("LOCAL_CODE")
+                    .WithId("Local Net4.8")); // custom config to include/exclude nuget reference or target project reference locally
+
+                AddJob(baseJob.WithRuntime(CoreRuntime.Core80).WithCustomBuildConfiguration("LOCAL_CODE")
+                    .WithId("Local Net8")); // custom config to include/exclude nuget reference or target project reference locally
+            }
+        }
+
+        [Benchmark]
+        public void ParseMessageAndGetValues()
+        {
+            var msg = new Message(_sampleMessage);
+            msg.ParseMessage(true);
+
+            var ack = msg.GetACK(true);
+            string sendingApp = ack.GetValue("MSH.3");
+            string sendingFacility = ack.GetValue("MSH.4");
+            string receivingApp = ack.GetValue("MSH.5");
+            string receivingFacility = ack.GetValue("MSH.6");
+            string messageType = ack.GetValue("MSH.9");
+        }
+    }
+}

--- a/Benchmarks/ParseMessageBench.cs
+++ b/Benchmarks/ParseMessageBench.cs
@@ -2,14 +2,15 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
+
 using HL7.Dotnetcore;
 using System.IO;
 
 namespace Benchmarks
 {
     /// <summary>
-    /// Basic benchmark comparing the nuget version to our local code, for both Framework 4.8 and net8.  Calls a copy of one of the tests
-    /// that best reflects my usage scenarios (Parse and GetValue)
+    /// Basic benchmark comparing the nuget version to the local code, for both .NET Framework 4.8 and .NET 8.0.  
+    /// Calls a copy of one of the tests that best reflects the usage scenarios (Parse and GetValue)
     /// </summary>
     [Config(typeof(Config))]
     [MemoryDiagnoser]
@@ -25,8 +26,6 @@ namespace Benchmarks
 | ParseMessageAndGetValues | Local Net8   | 50.55 us | 21.651 us | 1.187 us |  0.96 |    0.02 | 12.2070 | 2.0142 | 187.36 KB |        0.89 |
 | ParseMessageAndGetValues | Nuget Net4.8 | 97.66 us | 38.600 us | 2.116 us |  1.86 |    0.05 | 44.4336 | 6.8359 | 273.48 KB |        1.30 |
 | ParseMessageAndGetValues | Nuget Net8   | 52.39 us |  6.528 us | 0.358 us |  1.00 |    0.00 | 13.7329 | 2.3193 | 211.17 KB |        1.00 |
-
-
  */
 
         private class Config : ManualConfig

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -1,0 +1,16 @@
+// to run this targeting multiple frameworks, use 
+//   dotnet run -c Release -f net48 --filter "*"
+// I'm using net48 just to target the netstandard21 version of the library, and we're configured to bench the local code against teh nuget package
+
+using BenchmarkDotNet.Running;
+
+namespace Benchmarks
+{
+    internal class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(ParseMessageBench).Assembly).Run(args);
+        }
+    }
+}

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -1,0 +1,1 @@
+Set of general benchmarks for testing both different SDK versions, and also looking for improvements

--- a/Benchmarks/Sample-Orm.txt
+++ b/Benchmarks/Sample-Orm.txt
@@ -1,0 +1,7 @@
+MSH|^~\&|Organization||ALLINA||20170331171205||ORM^O01|3149|P|2.3||||NE
+PID|1|42311|42311|42311|Jane^Doe^T||19921112|M|||123 Worth Drive^^Troy^OH^45373^^Home||9373328660^Phone^Home^^^937^3338660|||||42311|111223333|||^Unknown^CDCREC
+PV1|1|1|^^^^^^^^Oak Ridge Big Name Location||||^Smith (M)^Michael|||||||||||||||||||||||||||||||||||||20170331
+ORC|NW|11777-60|||||^^^20170331||20170331171150|||^Smith (M)^Michael|^^^^^^^^Oak Ridge Big Name Location||20170331
+OBR|1|11777-60||4241^BRAZIL NUT (F18) IGE - 86003^AllinaCodes||20170331171150|20170331|||||||||^Smith (M)^Michael|||||||||||^^^201703311200
+NTE|1||some text\.br\some text after \H\new line\N\\.br\issue Efferent-Health#82
+NTE|1||some text\X0D\\X0A\some text after new line\X0D\\X0A\issue Efferent-Health#81

--- a/Benchmarks/readme.md
+++ b/Benchmarks/readme.md
@@ -1,0 +1,1 @@
+Set of general benchmarks for testing both different SDK versions, and also looking for improvements

--- a/Benchmarks/readme.md
+++ b/Benchmarks/readme.md
@@ -1,1 +1,0 @@
-Set of general benchmarks for testing both different SDK versions, and also looking for improvements

--- a/HL7-dotnetcore.sln
+++ b/HL7-dotnetcore.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "hl7-dotnetcore", "src\HL7-d
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "hl7test", "test\HL7test.csproj", "{910F6F49-6AD7-45EF-8FA0-E141C77D81DA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "Benchmarks\Benchmarks.csproj", "{27FBB293-28C9-43DE-919A-3128AC92A1ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,5 +46,17 @@ Global
 		{910F6F49-6AD7-45EF-8FA0-E141C77D81DA}.Release|x64.Build.0 = Release|x64
 		{910F6F49-6AD7-45EF-8FA0-E141C77D81DA}.Release|x86.ActiveCfg = Release|x86
 		{910F6F49-6AD7-45EF-8FA0-E141C77D81DA}.Release|x86.Build.0 = Release|x86
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Debug|x64.Build.0 = Debug|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Debug|x86.Build.0 = Debug|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Release|x64.ActiveCfg = Release|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Release|x64.Build.0 = Release|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{27FBB293-28C9-43DE-919A-3128AC92A1ED}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/ComponentCollection.cs
+++ b/src/ComponentCollection.cs
@@ -4,15 +4,13 @@ namespace HL7.Dotnetcore
 {
     internal class ComponentCollection : List<Component>
     {
-        
-        
         public ComponentCollection()
-        {}
+        {        
+        }
 
         public ComponentCollection(int initialCapacity) : base(initialCapacity)
-        {}
-
-
+        {        
+        }
         
         /// <summary>
         /// Component indexer

--- a/src/ComponentCollection.cs
+++ b/src/ComponentCollection.cs
@@ -4,6 +4,16 @@ namespace HL7.Dotnetcore
 {
     internal class ComponentCollection : List<Component>
     {
+        
+        
+        public ComponentCollection()
+        {}
+
+        public ComponentCollection(int initialCapacity) : base(initialCapacity)
+        {}
+
+
+        
         /// <summary>
         /// Component indexer
         /// </summary>

--- a/src/Encoding.cs
+++ b/src/Encoding.cs
@@ -37,15 +37,16 @@ namespace HL7.Dotnetcore
             }
         }
 
+        
+        private static readonly string[] _delimiters = { "\r\n", "\n\r", "\r", "\n" };
+        
         public void EvaluateSegmentDelimiter(string message)
         {
-            string[] delimiters = new[] { "\r\n", "\n\r", "\r", "\n" };
-
-            foreach (var delim in delimiters)
+            foreach (var delim in _delimiters)
             {
                 if (message.Contains(delim))
                 {
-                    this.SegmentDelimiter = delim;
+                    SegmentDelimiter = delim;
                     return;
                 }
             }
@@ -159,6 +160,12 @@ namespace HL7.Dotnetcore
         {
             if (string.IsNullOrWhiteSpace(encodedValue))
                 return encodedValue;
+            
+            if (!encodedValue.Contains(EscapeCharacter))
+            {
+                // no need to decode, just return as is
+                return encodedValue;
+            }
 
             var result = new StringBuilder();
 

--- a/src/Encoding.cs
+++ b/src/Encoding.cs
@@ -6,13 +6,13 @@ namespace HL7.Dotnetcore
 {
     public class HL7Encoding
     {
-        public char FieldDelimiter { get; set; } = '|'; // \F\
-        public char ComponentDelimiter { get; set; } = '^'; // \S\
-        public char RepeatDelimiter { get; set; } = '~';  // \R\
-        public char EscapeCharacter { get; set; } = '\\'; // \E\
+        public char FieldDelimiter { get; set; } = '|';        // \F\
+        public char ComponentDelimiter { get; set; } = '^';    // \S\
+        public char RepeatDelimiter { get; set; } = '~';       // \R\
+        public char EscapeCharacter { get; set; } = '\\';      // \E\
         public char SubComponentDelimiter { get; set; } = '&'; // \T\
-        public string SegmentDelimiter { get; set; } = "\r";
-        public string PresentButNull { get; set; } = "\"\"";
+        public string SegmentDelimiter { get; set; } = "\r";   // {cr}
+        public string PresentButNull { get; set; } = "\"\"";   // ""
         public string AllDelimiters => "" + FieldDelimiter + ComponentDelimiter + RepeatDelimiter + (EscapeCharacter == (char)0 ? "" : EscapeCharacter.ToString()) + SubComponentDelimiter;
 
         public HL7Encoding()
@@ -36,7 +36,6 @@ namespace HL7.Dotnetcore
                 this.SubComponentDelimiter = delimiters[4];
             }
         }
-
         
         private static readonly string[] _delimiters = { "\r\n", "\n\r", "\r", "\n" };
         
@@ -99,7 +98,9 @@ namespace HL7.Dotnetcore
                         i += 3; // +1 in loop
                     }
                     else
+                    {
                         continueEncoding = true;
+                    }
                 }
                 
                 if (continueEncoding)
@@ -189,7 +190,6 @@ namespace HL7.Dotnetcore
                     result.Append(encodedValue[i]);
                     continue;
                 }
-                
 
                 string seq = encodedValue.Substring(i, li-i);
                 i = li;

--- a/src/Field.cs
+++ b/src/Field.cs
@@ -135,18 +135,16 @@ namespace HL7.Dotnetcore
         public List<Field> Repetitions()
         {
             if (this.HasRepetitions)
-            {
                 return RepetitionList;
-            }
+
             return null;
         }
 
         public Field Repetitions(int repetitionNumber)
         {
             if (this.HasRepetitions)
-            {
                 return RepetitionList[repetitionNumber - 1];
-            }
+
             return null;
         }
 
@@ -169,15 +167,14 @@ namespace HL7.Dotnetcore
                 throw new HL7Exception("Error removing trailing components - " + ex.Message, ex);
             }
         }
-        public void AddRepeatingField(Field field) {
+        public void AddRepeatingField(Field field) 
+        {
             if (!this.HasRepetitions) 
-            {
                 throw new HL7Exception("Repeating field must have repetitions (HasRepetitions = true)");
-            }
+
             if (_RepetitionList == null) 
-            {
                 _RepetitionList = new List<Field>(); 
-            }
+
             _RepetitionList.Add(field);
         }
     }

--- a/src/Field.cs
+++ b/src/Field.cs
@@ -35,7 +35,7 @@ namespace HL7.Dotnetcore
             {
                 var subcomponent = new SubComponent(_value, this.Encoding);
 
-                this.ComponentList = new ComponentCollection();
+                this.ComponentList.Clear();
                 Component component = new Component(this.Encoding, true);
 
                 component.SubComponentList.Add(subcomponent);
@@ -61,7 +61,7 @@ namespace HL7.Dotnetcore
             {
                 List<string> allComponents = MessageHelper.SplitString(_value, this.Encoding.ComponentDelimiter);
 
-                this.ComponentList = new ComponentCollection();
+                this.ComponentList = new ComponentCollection(allComponents.Count);
 
                 foreach (string strComponent in allComponents)
                 {

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -66,10 +66,9 @@ namespace HL7.Dotnetcore
             try
             {
                 if (!bypassValidation)
-                {
                     isValid = this.validateMessage();
-                }
-                else { isValid = true; }
+                else
+                    isValid = true;
             }
             catch (HL7Exception ex)
             {
@@ -157,7 +156,6 @@ namespace HL7.Dotnetcore
                     foreach (Segment seg in _segListOrdered)
                     {
                         currentSegName = seg.Name;
-
                         strMessage.Append(seg.Name);
                         
                         if (seg.FieldList.Count > 0)
@@ -223,18 +221,20 @@ namespace HL7.Dotnetcore
             int componentIndex = 0;
             int subComponentIndex = 0;
             string strValue = string.Empty;
+            
             List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
-
             int comCount = allComponents.Count;
             bool isValid = validateValueFormat(allComponents);
 
             if (isValid)
             {
                 var matches = System.Text.RegularExpressions.Regex.Matches(allComponents[0], segmentRegex);
+                
                 if (matches.Count < 1)
                     throw new HL7Exception("Request format is not valid: " + strValueFormat);
 
                 segmentName = matches[0].Groups[1].Value;
+                
                 if (matches[0].Length > 3) 
                 {
                     Int32.TryParse(matches[0].Groups[3].Value, out segmentOccurrence);
@@ -243,7 +243,6 @@ namespace HL7.Dotnetcore
 
                 if (SegmentList.ContainsKey(segmentName))
                 {
-
                     var segment = SegmentList[segmentName][segmentOccurrence];
 
                     if (comCount == 4)
@@ -436,7 +435,6 @@ namespace HL7.Dotnetcore
             return isComponentized;
         }
 
-
         private static char[] _queryDelim = { '.' };
         /// <summary>
         /// Checks if specified fields has repetitions
@@ -575,6 +573,7 @@ namespace HL7.Dotnetcore
                     return false;
 
                 var list = SegmentList[segmentName];
+                
                 if (list.Count <= index)
                     return false;
 
@@ -762,15 +761,11 @@ namespace HL7.Dotnetcore
                 {
                     // Check message length - MSH+Delimeters+12Fields in MSH
                     if (HL7Message.Length < 20)
-                    {
                         throw new HL7Exception("Message Length too short: " + HL7Message.Length + " chars.", HL7Exception.BAD_MESSAGE);
-                    }
 
                     // Check if message starts with header segment
                     if (!HL7Message.StartsWith("MSH"))
-                    {
                         throw new HL7Exception("MSH segment not found at the beginning of the message", HL7Exception.BAD_MESSAGE);
-                    }
 
                     this.Encoding.EvaluateSegmentDelimiter(this.HL7Message);
                     this.HL7Message = string.Join(this.Encoding.SegmentDelimiter, MessageHelper.SplitMessage(this.HL7Message)) + this.Encoding.SegmentDelimiter;
@@ -788,14 +783,10 @@ namespace HL7.Dotnetcore
                         bool isValidSegmentName = System.Text.RegularExpressions.Regex.IsMatch(segmentName, segmentRegex);
 
                         if (!isValidSegmentName)
-                        {
                             throw new HL7Exception("Invalid segment name found: " + strSegment, HL7Exception.BAD_MESSAGE);
-                        }
 
                         if (strSegment.Length > 3 && fourthCharMSH != strSegment[3])
-                        {
                             throw new HL7Exception("Invalid segment found: " + strSegment, HL7Exception.BAD_MESSAGE);
-                        }
                     }
 
                     string _fieldDelimiters_Message = this.allSegments[0].Substring(3, 8 - 3);
@@ -805,21 +796,15 @@ namespace HL7.Dotnetcore
                     int countFieldSepInMSH = this.allSegments[0].Count(f => f == Encoding.FieldDelimiter);
 
                     if (countFieldSepInMSH < 11)
-                    {
                         throw new HL7Exception("MSH segment doesn't contain all the required fields", HL7Exception.BAD_MESSAGE);
-                    }
 
                     // Find Message Version
                     var MSHFields = MessageHelper.SplitString(this.allSegments[0], Encoding.FieldDelimiter);
 
                     if (MSHFields.Count >= 12)
-                    {
                         this.Version = MessageHelper.SplitString(this.Encoding.Decode(MSHFields[11]), Encoding.ComponentDelimiter)[0];
-                    }
                     else
-                    {
                         throw new HL7Exception("HL7 version not found in the MSH segment", HL7Exception.REQUIRED_FIELD_MISSING);
-                    }
 
                     // Find Message Type & Trigger Event
                     try
@@ -831,24 +816,18 @@ namespace HL7.Dotnetcore
                             var MSH_9_comps = MessageHelper.SplitString(MSH_9, this.Encoding.ComponentDelimiter);
 
                             if (MSH_9_comps.Count >= 3)
-                            {
                                 this.MessageStructure = MSH_9_comps[2];
-                            }
                             else if (MSH_9_comps.Count > 0 && MSH_9_comps[0] != null && MSH_9_comps[0].Equals("ACK"))
-                            {
                                 this.MessageStructure = "ACK";
-                            }
                             else if (MSH_9_comps.Count == 2)
-                            {
                                 this.MessageStructure = MSH_9_comps[0] + "_" + MSH_9_comps[1];
-                            }
                             else
-                            {
                                 throw new HL7Exception("Message Type & Trigger Event value not found in message", HL7Exception.UNSUPPORTED_MESSAGE_TYPE);
-                            }
                         }
                         else
+                        {
                             throw new HL7Exception("MSH.9 not available", HL7Exception.UNSUPPORTED_MESSAGE_TYPE);
+                        }
                     }
                     catch (System.IndexOutOfRangeException e)
                     {
@@ -903,6 +882,7 @@ namespace HL7.Dotnetcore
                 foreach (Component com in field.ComponentList)
                 {
                     indexCom++;
+                    
                     if (com.SubComponentList.Count > 0)
                         strMessage.Append(string.Join(Encoding.SubComponentDelimiter.ToString(), com.SubComponentList.Select(sc => Encoding.Encode(sc.Value))));
                     else
@@ -914,7 +894,6 @@ namespace HL7.Dotnetcore
             }
             else
                 strMessage.Append(Encoding.Encode(field.Value));
-
         }
 
         /// <summary> 

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -223,7 +223,7 @@ namespace HL7.Dotnetcore
             int componentIndex = 0;
             int subComponentIndex = 0;
             string strValue = string.Empty;
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, new char[] { '.' });
+            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
 
             int comCount = allComponents.Count;
             bool isValid = validateValueFormat(allComponents);
@@ -324,7 +324,7 @@ namespace HL7.Dotnetcore
             string segmentName = string.Empty;
             int componentIndex = 0;
             int subComponentIndex = 0;
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, new char[] { '.' });
+            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
             int comCount = allComponents.Count;
             bool isValid = validateValueFormat(allComponents);
 
@@ -405,7 +405,7 @@ namespace HL7.Dotnetcore
         {
             bool isComponentized = false;
             string segmentName = string.Empty;
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, new char[] { '.' });
+            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
             int comCount = allComponents.Count;
             bool isValid = validateValueFormat(allComponents);
 
@@ -436,6 +436,8 @@ namespace HL7.Dotnetcore
             return isComponentized;
         }
 
+
+        private static char[] _queryDelim = { '.' };
         /// <summary>
         /// Checks if specified fields has repetitions
         /// </summary>
@@ -443,15 +445,13 @@ namespace HL7.Dotnetcore
         /// <returns>boolean</returns>
         public bool HasRepetitions(string strValueFormat)
         {
-            string segmentName = string.Empty;
-
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, new char[] { '.' });
+            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
             int comCount = allComponents.Count;
             bool isValid = validateValueFormat(allComponents);
 
             if (isValid)
             {
-                segmentName = allComponents[0];
+                var segmentName = allComponents[0];
                 var segment = SegmentList[segmentName].First();
                 
                 if (comCount >= 2)
@@ -483,7 +483,7 @@ namespace HL7.Dotnetcore
             bool isSubComponentized = false;
             string segmentName = string.Empty;
             int componentIndex = 0;
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, new char[] { '.' });
+            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
             int comCount = allComponents.Count;
             bool isValid = validateValueFormat(allComponents);
 


### PR DESCRIPTION
Initial set of changes for #124 .

I've been working on multi-targeting both netstandard and net8, with some pretty dramatic performance improvements, but some of the changes didn't require modern .net, so I've pulled them out to here.

This includes the benchmark currently showing approx 5% runtime and 11% memory improvements cf the current code on Nuget.