### PR TITLE
feat: Last performance changes for message parse/query.  Another 20% …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ project.lock.json
 **/*.suo
 .vs
 .idea
+BenchmarkDotNet.Artifacts
+.DotSettings.user

--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -11,14 +11,13 @@
         </None>
     </ItemGroup>
 
-
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-        <PackageReference Include="HL7-dotnetcore" Version="2.37.1" Condition="!$(DefineConstants.Contains('LOCAL_CODE'))" />
+        <PackageReference Include="HL7-dotnetcore" Version="2.39" Condition="!$(DefineConstants.Contains('LOCAL_CODE'))" />
     </ItemGroup>
 
     <ItemGroup>
-        <!-- only include a direct code ref for net8, use nuget otherwise -->
+        <!-- only include a direct code ref if flag set, use nuget otherwise -->
         <ProjectReference Include="..\src\HL7-dotnetcore.csproj" Condition="$(DefineConstants.Contains('LOCAL_CODE'))" />
     </ItemGroup>
 

--- a/Benchmarks/ParseMessageBench.cs
+++ b/Benchmarks/ParseMessageBench.cs
@@ -14,19 +14,20 @@ namespace Benchmarks
     /// </summary>
     [Config(typeof(Config))]
     [MemoryDiagnoser]
-    [HideColumns("BuildConfiguration", "NuGetReferences", "Runtime")]
+    [HideColumns("BuildConfiguration", "Error", "StdDev", "RatioSD")]
     public class ParseMessageBench
     {
-        private readonly string _sampleMessage = File.ReadAllText("Sample-Orm.txt");
 
 /*
-| Method                   | Job          | Mean     | Error     | StdDev   | Ratio | RatioSD | Gen0    | Gen1   | Allocated | Alloc Ratio |
-|------------------------- |------------- |---------:|----------:|---------:|------:|--------:|--------:|-------:|----------:|------------:|
-| ParseMessageAndGetValues | Local Net4.8 | 96.03 us |  5.445 us | 0.298 us |  1.83 |    0.01 | 40.5273 | 5.9814 | 249.26 KB |        1.18 |
-| ParseMessageAndGetValues | Local Net8   | 50.55 us | 21.651 us | 1.187 us |  0.96 |    0.02 | 12.2070 | 2.0142 | 187.36 KB |        0.89 |
-| ParseMessageAndGetValues | Nuget Net4.8 | 97.66 us | 38.600 us | 2.116 us |  1.86 |    0.05 | 44.4336 | 6.8359 | 273.48 KB |        1.30 |
-| ParseMessageAndGetValues | Nuget Net8   | 52.39 us |  6.528 us | 0.358 us |  1.00 |    0.00 | 13.7329 | 2.3193 | 211.17 KB |        1.00 |
+| Method                   | Job          | Runtime            | NuGetReferences     | Mean     | Ratio | Gen0    | Gen1   | Allocated | Alloc Ratio |
+|------------------------- |------------- |------------------- |-------------------- |---------:|------:|--------:|-------:|----------:|------------:|
+| ParseMessageAndGetValues | Net4.8 Local | .NET Framework 4.8 | Default             | 75.54 us |  1.59 | 31.7383 | 4.3945 | 195.49 KB |        1.08 |
+| ParseMessageAndGetValues | Net4.8 Nuget | .NET Framework 4.8 | HL7-dotnetcore 2.39 | 99.49 us |  2.10 | 40.5273 | 6.1035 | 249.25 KB |        1.38 |
+| ParseMessageAndGetValues | Net8 Local   | .NET 8.0           | Default             | 33.67 us |  0.71 |  8.3008 | 1.3428 | 127.68 KB |        0.71 |
+| ParseMessageAndGetValues | Net8 Nuget   | .NET 8.0           | HL7-dotnetcore 2.39 | 47.40 us |  1.00 | 11.7798 | 1.9531 |  180.7 KB |        1.00 |
  */
+
+        internal static readonly string _sampleMessage = File.ReadAllText("Sample-Orm.txt");
 
         private class Config : ManualConfig
         {
@@ -34,14 +35,15 @@ namespace Benchmarks
             {
                 var baseJob = Job.ShortRun;
 
-                AddJob(baseJob.WithNuGet("HL7-dotnetcore", "2.37.1").WithRuntime(CoreRuntime.Core80).WithId("Nuget Net8").AsBaseline());
-                AddJob(baseJob.WithNuGet("HL7-dotnetcore", "2.37.1").WithRuntime(ClrRuntime.Net48).WithId("Nuget Net4.8"));
-
+                AddJob(baseJob.WithNuGet("HL7-dotnetcore", "2.39").WithRuntime(CoreRuntime.Core80).WithId("Net8 Nuget").AsBaseline());
+                AddJob(baseJob.WithNuGet("HL7-dotnetcore", "2.39").WithRuntime(ClrRuntime.Net48).WithId("Net4.8 Nuget"));
+                
                 AddJob(baseJob.WithRuntime(ClrRuntime.Net48).WithCustomBuildConfiguration("LOCAL_CODE")
-                    .WithId("Local Net4.8")); // custom config to include/exclude nuget reference or target project reference locally
-
+                    .WithId("Net4.8 Local")); // custom config to include/exclude nuget reference or target project reference locally
+                
                 AddJob(baseJob.WithRuntime(CoreRuntime.Core80).WithCustomBuildConfiguration("LOCAL_CODE")
-                    .WithId("Local Net8")); // custom config to include/exclude nuget reference or target project reference locally
+                    .WithId("Net8 Local")); // custom config to include/exclude nuget reference or target project reference locally
+
             }
         }
 

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -1,6 +1,6 @@
 // to run this targeting multiple frameworks, use 
 //   dotnet run -c Release -f net48 --filter "*"
-// I'm using net48 just to target the netstandard21 version of the library, and we're configured to bench the local code against teh nuget package
+// I'm using net48 just to target the netstandard21 version of the library, and we're configured to bench the local code against the nuget package
 
 using BenchmarkDotNet.Running;
 

--- a/src/Component.cs
+++ b/src/Component.cs
@@ -17,6 +17,7 @@ namespace HL7.Dotnetcore
             this.SubComponentList = new List<SubComponent>();
             this.Encoding = encoding;
         }
+
         public Component(string pValue, HL7Encoding encoding)
         {
             this.SubComponentList = new List<SubComponent>();
@@ -26,17 +27,18 @@ namespace HL7.Dotnetcore
 
         protected override void ProcessValue()
         {
-            List<string> allSubComponents;
-            
-            if (this.isDelimiter)
-                allSubComponents = new List<string>(new [] {this.Value});
-            else
-                allSubComponents = MessageHelper.SplitString(_value, this.Encoding.SubComponentDelimiter);
+            string[] allSubComponents;
 
-            if (allSubComponents.Count > 1)
+            if (this.isDelimiter)
+                allSubComponents = new[] { this.Value };
+            else
+                allSubComponents = _value.Split(this.Encoding.SubComponentDelimiter);
+
+            if (allSubComponents.Length > 1)
                 this.IsSubComponentized = true;
 
-            this.SubComponentList = new List<SubComponent>();
+            SubComponentList.Clear(); // in case there's existing data in there
+            SubComponentList.Capacity = allSubComponents.Length;
 
             foreach (string strSubComponent in allSubComponents)
             {

--- a/src/Field.cs
+++ b/src/Field.cs
@@ -48,10 +48,11 @@ namespace HL7.Dotnetcore
 
             if (this.HasRepetitions)
             {
-                _RepetitionList = new List<Field>();
-                List<string> individualFields = MessageHelper.SplitString(_value, this.Encoding.RepeatDelimiter);
+                var individualFields = _value.Split(this.Encoding.RepeatDelimiter);
+                _RepetitionList = new List<Field>(individualFields.Length);
+                
 
-                for (int index = 0; index < individualFields.Count; index++)
+                for (int index = 0; index < individualFields.Length; index++)
                 {
                     Field field = new Field(individualFields[index], this.Encoding);
                     _RepetitionList.Add(field);
@@ -59,9 +60,9 @@ namespace HL7.Dotnetcore
             }
             else
             {
-                List<string> allComponents = MessageHelper.SplitString(_value, this.Encoding.ComponentDelimiter);
+                var allComponents = _value.Split(this.Encoding.ComponentDelimiter);
 
-                this.ComponentList = new ComponentCollection(allComponents.Count);
+                this.ComponentList = new ComponentCollection(allComponents.Length);
 
                 foreach (string strComponent in allComponents)
                 {

--- a/src/Field.cs
+++ b/src/Field.cs
@@ -51,7 +51,6 @@ namespace HL7.Dotnetcore
                 var individualFields = _value.Split(this.Encoding.RepeatDelimiter);
                 _RepetitionList = new List<Field>(individualFields.Length);
                 
-
                 for (int index = 0; index < individualFields.Length; index++)
                 {
                     Field field = new Field(individualFields[index], this.Encoding);
@@ -168,6 +167,7 @@ namespace HL7.Dotnetcore
                 throw new HL7Exception("Error removing trailing components - " + ex.Message, ex);
             }
         }
+        
         public void AddRepeatingField(Field field) 
         {
             if (!this.HasRepetitions) 

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -19,7 +19,6 @@ namespace HL7.Dotnetcore
         public int SegmentCount { get; set; }
         public HL7Encoding Encoding { get; set; } = new HL7Encoding();
 
-        // we only need a char, but netstandard String.Split take a params array, so pay the alloc cost once here instead of per-split
         private static readonly char[] _queryDelimiter = { '.' }; 
 
         private const string segmentRegex = @"^([A-Z][A-Z][A-Z1-9])([\(\[]([0-9]+)[\)\]]){0,1}$";
@@ -190,7 +189,9 @@ namespace HL7.Dotnetcore
                                 }
                             }
                             else
+                            {
                                 serializeField(field, strMessage);
+                            }
                         }
                         
                         strMessage.Append(Encoding.SegmentDelimiter);
@@ -390,10 +391,14 @@ namespace HL7.Dotnetcore
 
                 }
                 else
+                {
                     throw new HL7Exception("Segment name not available");
+                }
             }
             else
+            {
                 throw new HL7Exception("Request format is not valid");
+            }
 
             return isSet;
         }
@@ -430,10 +435,14 @@ namespace HL7.Dotnetcore
                     }
                 }
                 else
+                {
                     throw new HL7Exception("Field not identified in request");
+                }
             }
             else
+            {
                 throw new HL7Exception("Request format is not valid");
+            }
 
             return isComponentized;
         }
@@ -467,10 +476,14 @@ namespace HL7.Dotnetcore
                     }
                 }
                 else
+                {
                     throw new HL7Exception("Field not identified in request");
+                }
             }
             else
+            {
                 throw new HL7Exception("Request format is not valid");
+            }
         }
 
         /// <summary>
@@ -507,10 +520,14 @@ namespace HL7.Dotnetcore
                     }
                 }
                 else
+                {
                     throw new HL7Exception("Component not identified in request");
+                }
             }
             else
+            {
                 throw new HL7Exception("Request format is not valid");
+            }
 
             return isSubComponentized;
         }
@@ -896,7 +913,9 @@ namespace HL7.Dotnetcore
                 }
             }
             else
+            {
                 strMessage.Append(Encoding.Encode(field.Value));
+            }
         }
 
         /// <summary> 

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -19,6 +19,9 @@ namespace HL7.Dotnetcore
         public int SegmentCount { get; set; }
         public HL7Encoding Encoding { get; set; } = new HL7Encoding();
 
+        // we only need a char, but netstandard String.Split take a params array, so pay the alloc cost once here instead of per-split
+        private static readonly char[] _queryDelimiter = { '.' }; 
+
         private const string segmentRegex = @"^([A-Z][A-Z][A-Z1-9])([\(\[]([0-9]+)[\)\]]){0,1}$";
         private const string fieldRegex = @"^([0-9]+)([\(\[]([0-9]+)[\)\]]){0,1}$";
         private const string otherRegEx = @"^[1-9]([0-9]{1,2})?$";
@@ -39,8 +42,8 @@ namespace HL7.Dotnetcore
 
             if (obj is string)
             {
-                var arr1 = MessageHelper.SplitString(this.HL7Message, this.Encoding.SegmentDelimiter, StringSplitOptions.RemoveEmptyEntries);
-                var arr2 = MessageHelper.SplitString(obj as string, this.Encoding.SegmentDelimiter, StringSplitOptions.RemoveEmptyEntries);
+                var arr1 = this.HL7Message.Split(this.Encoding.SegmentDelimiter.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+                var arr2 = (obj as string).Split(this.Encoding.SegmentDelimiter.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
 
                 return arr1.SequenceEqual(arr2);
             }
@@ -105,7 +108,7 @@ namespace HL7.Dotnetcore
 
                     this.SegmentCount = segSeqNo;
 
-                    string strSerializedMessage = string.Empty;
+                    string strSerializedMessage;
 
                     try
                     {
@@ -210,7 +213,7 @@ namespace HL7.Dotnetcore
         }
 
         /// <summary>
-        /// Get the Value of specific Field/Component/SubCpomponent, throws error if field/component index is not valid
+        /// Get the Value of specific Field/Component/SubComponent, throws error if field/component index is not valid
         /// </summary>
         /// <param name="strValueFormat">Field/Component position in format SEGMENTNAME.FieldIndex.ComponentIndex.SubComponentIndex example PID.5.2</param>
         /// <returns>Value of specified field/component/subcomponent</returns>
@@ -222,8 +225,8 @@ namespace HL7.Dotnetcore
             int subComponentIndex = 0;
             string strValue = string.Empty;
             
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
-            int comCount = allComponents.Count;
+            var allComponents = strValueFormat.Split(_queryDelimiter);
+            int comCount = allComponents.Length;
             bool isValid = validateValueFormat(allComponents);
 
             if (isValid)
@@ -323,8 +326,8 @@ namespace HL7.Dotnetcore
             string segmentName = string.Empty;
             int componentIndex = 0;
             int subComponentIndex = 0;
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
-            int comCount = allComponents.Count;
+            var allComponents = strValueFormat.Split(_queryDelimiter);
+            int comCount = allComponents.Length;
             bool isValid = validateValueFormat(allComponents);
 
             if (isValid)
@@ -404,8 +407,8 @@ namespace HL7.Dotnetcore
         {
             bool isComponentized = false;
             string segmentName = string.Empty;
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
-            int comCount = allComponents.Count;
+            var allComponents = strValueFormat.Split(_queryDelimiter);
+            int comCount = allComponents.Length;
             bool isValid = validateValueFormat(allComponents);
 
             if (isValid)
@@ -435,7 +438,6 @@ namespace HL7.Dotnetcore
             return isComponentized;
         }
 
-        private static char[] _queryDelim = { '.' };
         /// <summary>
         /// Checks if specified fields has repetitions
         /// </summary>
@@ -443,8 +445,8 @@ namespace HL7.Dotnetcore
         /// <returns>boolean</returns>
         public bool HasRepetitions(string strValueFormat)
         {
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
-            int comCount = allComponents.Count;
+            var allComponents = strValueFormat.Split(_queryDelimiter);
+            int comCount = allComponents.Length;
             bool isValid = validateValueFormat(allComponents);
 
             if (isValid)
@@ -481,8 +483,8 @@ namespace HL7.Dotnetcore
             bool isSubComponentized = false;
             string segmentName = string.Empty;
             int componentIndex = 0;
-            List<string> allComponents = MessageHelper.SplitString(strValueFormat, _queryDelim);
-            int comCount = allComponents.Count;
+            var allComponents = strValueFormat.Split(_queryDelimiter);
+            int comCount = allComponents.Length;
             bool isValid = validateValueFormat(allComponents);
 
             if (isValid)
@@ -768,11 +770,12 @@ namespace HL7.Dotnetcore
                         throw new HL7Exception("MSH segment not found at the beginning of the message", HL7Exception.BAD_MESSAGE);
 
                     this.Encoding.EvaluateSegmentDelimiter(this.HL7Message);
-                    this.HL7Message = string.Join(this.Encoding.SegmentDelimiter, MessageHelper.SplitMessage(this.HL7Message)) + this.Encoding.SegmentDelimiter;
+                    this.allSegments = MessageHelper.SplitMessage(HL7Message);
+                    
+                    this.HL7Message = string.Join(this.Encoding.SegmentDelimiter, allSegments) + this.Encoding.SegmentDelimiter;
 
                     // Check Segment Name & 4th character of each segment
                     char fourthCharMSH = HL7Message[3];
-                    this.allSegments = MessageHelper.SplitMessage(HL7Message);
 
                     foreach (string strSegment in this.allSegments)
                     {
@@ -799,10 +802,10 @@ namespace HL7.Dotnetcore
                         throw new HL7Exception("MSH segment doesn't contain all the required fields", HL7Exception.BAD_MESSAGE);
 
                     // Find Message Version
-                    var MSHFields = MessageHelper.SplitString(this.allSegments[0], Encoding.FieldDelimiter);
+                    var MSHFields = this.allSegments[0].Split(Encoding.FieldDelimiter);
 
-                    if (MSHFields.Count >= 12)
-                        this.Version = MessageHelper.SplitString(this.Encoding.Decode(MSHFields[11]), Encoding.ComponentDelimiter)[0];
+                    if (MSHFields.Length >= 12)
+                        this.Version = this.Encoding.Decode(MSHFields[11]).Split(Encoding.ComponentDelimiter)[0];
                     else
                         throw new HL7Exception("HL7 version not found in the MSH segment", HL7Exception.REQUIRED_FIELD_MISSING);
 
@@ -813,13 +816,13 @@ namespace HL7.Dotnetcore
 
                         if (!string.IsNullOrEmpty(MSH_9))
                         {
-                            var MSH_9_comps = MessageHelper.SplitString(MSH_9, this.Encoding.ComponentDelimiter);
+                            var MSH_9_comps = MSH_9.Split(this.Encoding.ComponentDelimiter);
 
-                            if (MSH_9_comps.Count >= 3)
+                            if (MSH_9_comps.Length >= 3)
                                 this.MessageStructure = MSH_9_comps[2];
-                            else if (MSH_9_comps.Count > 0 && MSH_9_comps[0] != null && MSH_9_comps[0].Equals("ACK"))
+                            else if (MSH_9_comps.Length > 0 && MSH_9_comps[0] != null && MSH_9_comps[0].Equals("ACK"))
                                 this.MessageStructure = "ACK";
-                            else if (MSH_9_comps.Count == 2)
+                            else if (MSH_9_comps.Length == 2)
                                 this.MessageStructure = MSH_9_comps[0] + "_" + MSH_9_comps[1];
                             else
                                 throw new HL7Exception("Message Type & Trigger Event value not found in message", HL7Exception.UNSUPPORTED_MESSAGE_TYPE);
@@ -919,15 +922,15 @@ namespace HL7.Dotnetcore
         /// Validates the components of a value's position descriptor
         /// </summary>
         /// <returns>A boolean indicating whether all the components are valid or not</returns>
-        private bool validateValueFormat(List<string> allComponents)
+        private bool validateValueFormat(string[] allComponents)
         {
             bool isValid = false;
 
-            if (allComponents.Count > 0)
+            if (allComponents.Length > 0)
             {
                 if (Regex.IsMatch(allComponents[0], segmentRegex))
                 {
-                    for (int i = 1; i < allComponents.Count; i++)
+                    for (int i = 1; i < allComponents.Length; i++)
                     {
                         if (i == 1 && Regex.IsMatch(allComponents[i], fieldRegex))
                             isValid = true;

--- a/src/MessageHelper.cs
+++ b/src/MessageHelper.cs
@@ -43,7 +43,9 @@ namespace HL7.Dotnetcore
             var list = new List<string>();
 
             foreach (Match m in matches)
+            {
                 list.Add(m.Groups[1].Value);
+            }
 
             return list.ToArray();
         }

--- a/src/MessageHelper.cs
+++ b/src/MessageHelper.cs
@@ -9,7 +9,7 @@ namespace HL7.Dotnetcore
 {
     public static class MessageHelper
     {
-        private static string[] lineSeparators = { "\r\n", "\n\r", "\r", "\n" };
+        private static readonly string[] lineSeparators = { "\r\n", "\n\r", "\r", "\n" };
 
         public static List<string> SplitString(string strStringToSplit, string splitBy, StringSplitOptions splitOptions = StringSplitOptions.None)
         {

--- a/src/Segment.cs
+++ b/src/Segment.cs
@@ -25,16 +25,14 @@ namespace HL7.Dotnetcore
 
         protected override void ProcessValue()
         {
-            List<string> allFields = MessageHelper.SplitString(_value, this.Encoding.FieldDelimiter);
-
-            allFields.RemoveAt(0);
+            var allFields = _value.Split(this.Encoding.FieldDelimiter);
             
-            for (int i = 0; i < allFields.Count; i++)
+            for (int i = 1; i < allFields.Length; i++)
             {
                 string strField = allFields[i];
                 Field field = new Field(this.Encoding);   
 
-                if (Name == "MSH" && i == 0)
+                if (Name == "MSH" && i == 1)
                     field.IsDelimitersField = true; // special case
 
                 field.Value = strField;


### PR DESCRIPTION
…compared to latest nuget for net8, and even more for framework48.

There is a small change to public API here, `MessageHelper.Split` is now retuning an array instead of a `List`.  These feel like methods that _should_ be `internal`, but they've been exposed publicly and we can't take it back.

If you're not happy with the change to public API then just let me know and I'll call `String.Split` directly for those call sites - the helper doesn't exaclty add a lot of value.

If there's anything else that isn't up to snuff re: coding standards or something just let me know 👍

